### PR TITLE
NewFromUintRawNocopy and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bitmask
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/astef/bitmask.svg)](https://pkg.go.dev/github.com/astef/bitmask) ![Coverage Badge](https://img.shields.io/badge/coverage-97.5%25-green.svg)
+[![Go Reference](https://pkg.go.dev/badge/github.com/astef/bitmask.svg)](https://pkg.go.dev/github.com/astef/bitmask) ![Coverage Badge](https://img.shields.io/badge/coverage-97.6%25-green.svg)
 
 Arbitrary size bitmask (aka bitset) with efficient Slice method.
 

--- a/bitmask.go
+++ b/bitmask.go
@@ -45,6 +45,12 @@ func NewFromUintRaw(values ...uint) *BitMask {
 	return &BitMask{store: store, len: uintSize * uint(len(values))}
 }
 
+// Works like NewFromUintRaw, but doesn't create own buffer for bits. Helps reducing heap allocations.
+// Use with caution, since shared buffer is the likely source of complex bugs.
+func NewFromUintRawNocopy(values ...uint) *BitMask {
+	return &BitMask{store: values, len: uintSize * uint(len(values))}
+}
+
 // Returns the legth of bitmask in bits. It will never be changed for the given receiver.
 func (bm *BitMask) Len() uint {
 	return bm.len

--- a/bitmask_test.go
+++ b/bitmask_test.go
@@ -730,13 +730,43 @@ func TestUintRaw(t *testing.T) {
 
 	assert.Equal(t, 3, bm.LenUint())
 
-	assert.Equal(t, []int{ uintSize - 1, uintSize + uintSize - 1 }, indexes)
+	assert.Equal(t, []int{uintSize - 1, uintSize + uintSize - 1}, indexes)
 
-	assert.Equal(t, uint(1 << 63), bm.Uint(0))
-	assert.Equal(t, uint(1 << 63), bm.Uint(1))
+	assert.Equal(t, uint(1<<63), bm.Uint(0))
+	assert.Equal(t, uint(1<<63), bm.Uint(1))
 	assert.Equal(t, uint(0), bm.Uint(2))
-	
+
 	assert.Equal(t, uint(1), bm.UintRaw(0))
 	assert.Equal(t, uint(1), bm.UintRaw(1))
-	assert.Equal(t, uint(0), bm.UintRaw(2))	
+	assert.Equal(t, uint(0), bm.UintRaw(2))
+}
+
+func TestUintRawNocopy(t *testing.T) {
+	buf := []uint{1, 1, 0}
+	bm := NewFromUintRawNocopy(buf...)
+	indexes := indexes(bm.Iterator())
+
+	assert.Equal(t, 3, bm.LenUint())
+
+	assert.Equal(t, []int{uintSize - 1, uintSize + uintSize - 1}, indexes)
+
+	assert.Equal(t, uint(1<<63), bm.Uint(0))
+	assert.Equal(t, uint(1<<63), bm.Uint(1))
+	assert.Equal(t, uint(0), bm.Uint(2))
+
+	assert.Equal(t, uint(1), bm.UintRaw(0))
+	assert.Equal(t, uint(1), bm.UintRaw(1))
+	assert.Equal(t, uint(0), bm.UintRaw(2))
+
+	// modify own buffer and see bitmask has changed
+	buf[0], buf[2] = buf[2], buf[0]
+	assert.Equal(t, 3, bm.LenUint())
+
+	assert.Equal(t, uint(0), bm.Uint(0))
+	assert.Equal(t, uint(1<<63), bm.Uint(1))
+	assert.Equal(t, uint(1<<63), bm.Uint(2))
+
+	assert.Equal(t, uint(0), bm.UintRaw(0))
+	assert.Equal(t, uint(1), bm.UintRaw(1))
+	assert.Equal(t, uint(1), bm.UintRaw(2))
 }


### PR DESCRIPTION
I noticed we can help avoid heap allocation by introducing constructor without buffer copy. It's not safe, but helpful, when you optimize stuff